### PR TITLE
use router dispatch start events to update name of span

### DIFF
--- a/lib/opentelemetry_plug.ex
+++ b/lib/opentelemetry_plug.ex
@@ -12,7 +12,7 @@ defmodule OpentelemetryPlug do
 
   Example:
 
-      OpentelemetryPlug.setup([:my, :plug])
+      OpentelemetryPlug.setup([])
 
   You may also supply the following options in the second argument:
 
@@ -23,7 +23,7 @@ defmodule OpentelemetryPlug do
       defaults to the concatenation of the event name with periods, e.g.
       `"my.plug.start"`.
   """
-  def setup(event_prefix, config \\ []) do
+  def setup(config \\ []) do
     # register the tracer. just re-registers if called for multiple repos
     _ = OpenTelemetry.register_application_tracer(:opentelemetry_plug)
 

--- a/mix.exs
+++ b/mix.exs
@@ -21,7 +21,7 @@ defmodule OpentelemetryPlug.MixProject do
   # Run "mix help deps" to learn about dependencies.
   defp deps do
     [
-      {:plug, "~> 1.10"},
+      {:plug, github: "elixir-plug/plug", branch: "master"},
       {:opentelemetry_api, "~> 0.3"},
       {:opentelemetry, "~> 0.3"},
       {:telemetry, "~> 0.4"}

--- a/mix.lock
+++ b/mix.lock
@@ -2,7 +2,7 @@
   "mime": {:hex, :mime, "1.3.1", "30ce04ab3175b6ad0bdce0035cba77bba68b813d523d1aac73d9781b4d193cf8", [:mix], [], "hexpm", "6cbe761d6a0ca5a31a0931bf4c63204bceb64538e664a8ecf784a9a6f3b875f1"},
   "opentelemetry": {:hex, :opentelemetry, "0.4.0", "293729f014009b03a1a2c47e6367db6f280b41412faa5639f06dcce9733d18a6", [:rebar3], [{:opentelemetry_api, "~> 0.3.1", [hex: :opentelemetry_api, repo: "hexpm", optional: false]}], "hexpm", "f0eb4281f26879147322b0a6f1c457c57f3f1c4121cbff1f6056e4c98b1647a7"},
   "opentelemetry_api": {:hex, :opentelemetry_api, "0.3.1", "aa042f9ff0b774c3e9827e215fcf972d5cfccd9a79ed55194b58c329a945b486", [:mix, :rebar3], [], "hexpm", "91fc78c521b9fc7f72f47144bb9f0838d57584b1be5bbd3098d8aaf2f2d42686"},
-  "plug": {:hex, :plug, "1.10.0", "6508295cbeb4c654860845fb95260737e4a8838d34d115ad76cd487584e2fc4d", [:mix], [{:mime, "~> 1.0", [hex: :mime, repo: "hexpm", optional: false]}, {:plug_crypto, "~> 1.1.1 or ~> 1.2", [hex: :plug_crypto, repo: "hexpm", optional: false]}, {:telemetry, "~> 0.4", [hex: :telemetry, repo: "hexpm", optional: true]}], "hexpm", "422a9727e667be1bf5ab1de03be6fa0ad67b775b2d84ed908f3264415ef29d4a"},
+  "plug": {:git, "https://github.com/elixir-plug/plug.git", "9c880dee5a3d55c81f97a87076e540a9b5878cbd", [branch: "master"]},
   "plug_crypto": {:hex, :plug_crypto, "1.1.2", "bdd187572cc26dbd95b87136290425f2b580a116d3fb1f564216918c9730d227", [:mix], [], "hexpm", "6b8b608f895b6ffcfad49c37c7883e8df98ae19c6a28113b02aa1e9c5b22d6b5"},
   "telemetry": {:hex, :telemetry, "0.4.1", "ae2718484892448a24470e6aa341bc847c3277bfb8d4e9289f7474d752c09c7f", [:rebar3], [], "hexpm", "4738382e36a0a9a2b6e25d67c960e40e1a2c95560b9f936d8e29de8cd858480f"},
 }

--- a/test/opentelemetry_plug_test.exs
+++ b/test/opentelemetry_plug_test.exs
@@ -39,7 +39,6 @@ defmodule MyRouter do
   use Plug.Router
 
   plug :match
-  plug Plug.Telemetry, event_prefix: [:my, :plug]
   plug :dispatch
 
   forward "/hello/:foo", to: MyPlug


### PR DESCRIPTION
Instead of creating the span on `Plug.Telemetry` events it now uses the plug adapter events and the router dispatch event to update the name to the name of the route.

Depends on this patch to Plug https://github.com/elixir-plug/plug/pull/934 so uses the github repo as the dep until a new release is made.